### PR TITLE
Add cycle reset and history tracking

### DIFF
--- a/lib/data/firebase_service.dart
+++ b/lib/data/firebase_service.dart
@@ -2,6 +2,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:pomodoro_desktop/data/model/shop_item.dart';
+import 'package:pomodoro_desktop/data/model/day_record.dart';
+import 'package:pomodoro_desktop/data/model/cycle_record.dart';
 import '../firebase_options.dart';
 
 class FirebaseService {
@@ -48,6 +50,17 @@ class FirebaseService {
           .map((item) => item.toJson())
           .toList();
     }
+    if (dataToSave.containsKey('todayCycles')) {
+      dataToSave['todayCycles'] =
+          (dataToSave['todayCycles'] as List<CycleRecord>)
+              .map((e) => e.toJson())
+              .toList();
+    }
+    if (dataToSave.containsKey('history')) {
+      dataToSave['history'] = (dataToSave['history'] as List<DayRecord>)
+          .map((e) => e.toJson())
+          .toList();
+    }
 
     await db
         .collection('artifacts')
@@ -81,6 +94,8 @@ class FirebaseService {
         'cycleCount': 0,
         'energyHistory': [],
         'complexityHistory': [],
+        'todayCycles': [],
+        'history': [],
       });
       print('✅ 사용자 초기 데이터 생성 완료');
     }

--- a/lib/data/model/cycle_record.dart
+++ b/lib/data/model/cycle_record.dart
@@ -1,0 +1,27 @@
+class CycleRecord {
+  final String goal;
+  final int complexity;
+  final int energy;
+
+  CycleRecord({
+    required this.goal,
+    required this.complexity,
+    required this.energy,
+  });
+
+  factory CycleRecord.fromJson(Map<String, dynamic> json) {
+    return CycleRecord(
+      goal: json['goal'] ?? '',
+      complexity: json['complexity'] ?? 1,
+      energy: json['energy'] ?? 1,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'goal': goal,
+      'complexity': complexity,
+      'energy': energy,
+    };
+  }
+}

--- a/lib/data/model/day_record.dart
+++ b/lib/data/model/day_record.dart
@@ -1,0 +1,24 @@
+import 'cycle_record.dart';
+
+class DayRecord {
+  final String date;
+  final List<CycleRecord> cycles;
+
+  DayRecord({required this.date, required this.cycles});
+
+  factory DayRecord.fromJson(Map<String, dynamic> json) {
+    return DayRecord(
+      date: json['date'] ?? '',
+      cycles: (json['cycles'] as List? ?? [])
+          .map((e) => CycleRecord.fromJson(Map<String, dynamic>.from(e)))
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'date': date,
+      'cycles': cycles.map((e) => e.toJson()).toList(),
+    };
+  }
+}

--- a/lib/feature/pomodoro/widgets/cycle_history_widget.dart
+++ b/lib/feature/pomodoro/widgets/cycle_history_widget.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:pomodoro_desktop/data/model/cycle_record.dart';
+
+class CycleHistoryPopup extends StatefulWidget {
+  final Map<String, List<CycleRecord>> history;
+  final List<CycleRecord> todayCycles;
+  final VoidCallback onClose;
+
+  const CycleHistoryPopup({
+    super.key,
+    required this.history,
+    required this.todayCycles,
+    required this.onClose,
+  });
+
+  @override
+  State<CycleHistoryPopup> createState() => _CycleHistoryPopupState();
+}
+
+class _CycleHistoryPopupState extends State<CycleHistoryPopup> {
+  late String _selectedDate;
+  late Map<String, List<CycleRecord>> _allHistory;
+
+  @override
+  void initState() {
+    super.initState();
+    final today = _todayString();
+    _allHistory = {...widget.history, today: widget.todayCycles};
+    _selectedDate = today;
+  }
+
+  String _todayString() {
+    final now = DateTime.now();
+    return '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cycles = _allHistory[_selectedDate] ?? [];
+    return AlertDialog(
+      title: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          DropdownButton<String>(
+            value: _selectedDate,
+            items: _allHistory.keys
+                .map((d) => DropdownMenuItem(value: d, child: Text(d)))
+                .toList(),
+            onChanged: (v) => setState(() => _selectedDate = v ?? _selectedDate),
+          ),
+          IconButton(onPressed: widget.onClose, icon: const Icon(Icons.close)),
+        ],
+      ),
+      content: SingleChildScrollView(
+        child: DataTable(
+          columns: const [
+            DataColumn(label: Text('#')),
+            DataColumn(label: Text('목표')),
+            DataColumn(label: Text('난이도')),
+            DataColumn(label: Text('에너지')),
+          ],
+          rows: List.generate(cycles.length, (index) {
+            final c = cycles[index];
+            return DataRow(cells: [
+              DataCell(Text('${index + 1}')),
+              DataCell(Text(c.goal)),
+              DataCell(Text('${c.complexity}')),
+              DataCell(Text('${c.energy}')),
+            ]);
+          }),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new model classes `CycleRecord` and `DayRecord`
- extend `FirebaseService` to save cycle history
- add cycle history popup widget
- implement cycle tracking, reset, and history view in `PomodoroPage`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475cbf1fd8833287271dea4363461e