### PR TITLE
Add weekly summary and detail views

### DIFF
--- a/lib/data/firebase_service.dart
+++ b/lib/data/firebase_service.dart
@@ -4,6 +4,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:pomodoro_desktop/data/model/shop_item.dart';
 import 'package:pomodoro_desktop/data/model/day_record.dart';
 import 'package:pomodoro_desktop/data/model/cycle_record.dart';
+import 'package:pomodoro_desktop/data/model/schedule.dart';
 import '../firebase_options.dart';
 
 class FirebaseService {
@@ -61,6 +62,10 @@ class FirebaseService {
           .map((e) => e.toJson())
           .toList();
     }
+    if (dataToSave.containsKey('schedule')) {
+      dataToSave['schedule'] =
+          (dataToSave['schedule'] as Schedule).toJson();
+    }
 
     await db
         .collection('artifacts')
@@ -90,12 +95,18 @@ class FirebaseService {
         'currentGoal': '',
         'focusMinutes': 25,
         'breakMinutes': 5,
+        'longBreakMinutes': 15,
+        'longBreakInterval': 4,
         'inventory': [],
         'cycleCount': 0,
         'energyHistory': [],
         'complexityHistory': [],
         'todayCycles': [],
         'history': [],
+        'schedule': Schedule.empty(
+          const ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+          17,
+        ).toJson(),
       });
       print('✅ 사용자 초기 데이터 생성 완료');
     }

--- a/lib/data/model/cycle_record.dart
+++ b/lib/data/model/cycle_record.dart
@@ -2,11 +2,13 @@ class CycleRecord {
   final String goal;
   final int complexity;
   final int energy;
+  final String startTime;
 
   CycleRecord({
     required this.goal,
     required this.complexity,
     required this.energy,
+    required this.startTime,
   });
 
   factory CycleRecord.fromJson(Map<String, dynamic> json) {
@@ -14,6 +16,7 @@ class CycleRecord {
       goal: json['goal'] ?? '',
       complexity: json['complexity'] ?? 1,
       energy: json['energy'] ?? 1,
+      startTime: json['startTime'] ?? '',
     );
   }
 
@@ -22,6 +25,7 @@ class CycleRecord {
       'goal': goal,
       'complexity': complexity,
       'energy': energy,
+      'startTime': startTime,
     };
   }
 }

--- a/lib/data/model/schedule.dart
+++ b/lib/data/model/schedule.dart
@@ -1,0 +1,23 @@
+class Schedule {
+  final Map<String, List<String>> days;
+
+  Schedule({required this.days});
+
+  factory Schedule.empty(List<String> dayKeys, int slotCount) {
+    return Schedule(
+      days: {
+        for (var d in dayKeys) d: List.filled(slotCount, 'none'),
+      },
+    );
+  }
+
+  factory Schedule.fromJson(Map<String, dynamic> json) {
+    final map = <String, List<String>>{};
+    for (final entry in json.entries) {
+      map[entry.key] = (entry.value as List).map((e) => e.toString()).toList();
+    }
+    return Schedule(days: map);
+  }
+
+  Map<String, dynamic> toJson() => days;
+}

--- a/lib/feature/home/home_page.dart
+++ b/lib/feature/home/home_page.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import '../pomodoro/pomodoro_page.dart';
+import '../report/report_page.dart';
+import '../settings/settings_page.dart';
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  int _currentIndex = 0;
+
+  final List<Widget> _pages = const [
+    PomodoroPage(),
+    ReportPage(),
+    SettingsPage(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(
+        index: _currentIndex,
+        children: _pages,
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: (index) => setState(() => _currentIndex = index),
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.timer),
+            label: '타이머',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.bar_chart),
+            label: '레포트',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.settings),
+            label: '설정',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/feature/pomodoro/widgets/energy_graph_widget.dart
+++ b/lib/feature/pomodoro/widgets/energy_graph_widget.dart
@@ -26,6 +26,67 @@ class EnergyGraph extends StatelessWidget {
   }
 }
 
+class HourlyGraph extends StatelessWidget {
+  final List<double> levels;
+  final String title;
+
+  const HourlyGraph({super.key, required this.levels, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title,
+            style:
+                const TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
+        const SizedBox(height: 8),
+        SizedBox(
+          height: 150,
+          width: double.infinity,
+          child: CustomPaint(painter: _HourlyPainter(levels)),
+        ),
+      ],
+    );
+  }
+}
+
+class _HourlyPainter extends CustomPainter {
+  final List<double> levels;
+
+  _HourlyPainter(this.levels);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.purple
+      ..strokeWidth = 2
+      ..style = PaintingStyle.stroke;
+    final stepX = size.width / (levels.length - 1 == 0 ? 1 : levels.length - 1);
+    final stepY = size.height / 3;
+    final path = Path();
+    for (var i = 0; i < levels.length; i++) {
+      final x = i * stepX;
+      final y = size.height - levels[i] * stepY;
+      if (i == 0) {
+        path.moveTo(x, y);
+      } else {
+        path.lineTo(x, y);
+      }
+    }
+    canvas.drawPath(path, paint);
+
+    final axisPaint = Paint()
+      ..color = Colors.grey
+      ..strokeWidth = 1;
+    canvas.drawLine(Offset(0, size.height), Offset(size.width, size.height), axisPaint);
+    canvas.drawLine(Offset(0, 0), Offset(0, size.height), axisPaint);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+}
+
 class _EnergyPainter extends CustomPainter {
   final List<int> levels;
   _EnergyPainter(this.levels);

--- a/lib/feature/pomodoro/widgets/popup_widget.dart
+++ b/lib/feature/pomodoro/widgets/popup_widget.dart
@@ -171,3 +171,28 @@ class EnergyLevelPopup extends StatelessWidget {
     );
   }
 }
+
+class ComplexityLevelPopup extends StatelessWidget {
+  final void Function(int) onSelect;
+
+  const ComplexityLevelPopup({super.key, required this.onSelect});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24.0)),
+      title: const Text('난이도는?',
+          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 22)),
+      content: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: List.generate(
+          3,
+          (index) => ElevatedButton(
+            onPressed: () => onSelect(index + 1),
+            child: Text('${index + 1}'),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/feature/report/report_page.dart
+++ b/lib/feature/report/report_page.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import '../../data/firebase_service.dart';
+import '../../data/model/day_record.dart';
+import '../../data/model/cycle_record.dart';
+import '../pomodoro/widgets/energy_graph_widget.dart';
+
+class ReportPage extends StatefulWidget {
+  const ReportPage({super.key});
+
+  @override
+  State<ReportPage> createState() => _ReportPageState();
+}
+
+class _ReportPageState extends State<ReportPage> {
+  final FirebaseService _firebaseService = FirebaseService();
+  String _userId = '';
+  List<DayRecord> _history = [];
+  List<CycleRecord> _todayCycles = [];
+  bool _loading = true;
+  String _selectedDate = '';
+
+  static const _startHour = 7;
+  static const _endHour = 23;
+
+  @override
+  void initState() {
+    super.initState();
+    _initialize();
+  }
+
+  Future<void> _initialize() async {
+    await _firebaseService.initializeFirebase();
+    _userId = (await _firebaseService.authenticateUser()) ?? '';
+    _firebaseService.getUserDataStream(_userId).listen((snapshot) {
+      final data = snapshot.data();
+      if (data != null) {
+        setState(() {
+          _history = (data['history'] as List? ?? [])
+              .map((e) => DayRecord.fromJson(Map<String, dynamic>.from(e)))
+              .toList();
+          _todayCycles = (data['todayCycles'] as List? ?? [])
+              .map((e) => CycleRecord.fromJson(Map<String, dynamic>.from(e)))
+              .toList();
+          _selectedDate = _formatDate(DateTime.now());
+          _loading = false;
+        });
+      }
+    });
+  }
+
+  String _formatDate(DateTime d) {
+    return '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+  }
+
+  List<String> _availableDates() {
+    final dates = _history.map((e) => e.date).toSet().toList();
+    final today = _formatDate(DateTime.now());
+    if (!dates.contains(today)) dates.add(today);
+    dates.sort();
+    return dates;
+  }
+
+  List<CycleRecord> _getCycles(String date) {
+    if (date == _formatDate(DateTime.now())) {
+      return _todayCycles;
+    }
+    return _history
+            .firstWhere((d) => d.date == date, orElse: () => DayRecord(date: date, cycles: const []))
+            .cycles;
+  }
+
+  Map<String, int> _weeklyMinutes() {
+    final now = DateTime.now();
+    final map = <String, int>{};
+    for (var i = 0; i < 7; i++) {
+      final day = now.subtract(Duration(days: i));
+      final key = _formatDate(day);
+      final cycles = _getCycles(key);
+      map[key] = cycles.length * 25;
+    }
+    final ordered = map.keys.toList()..sort();
+    return {for (var k in ordered) k: map[k] ?? 0};
+  }
+
+  List<double> _hourlyLevels(String date, {required bool energy}) {
+    final cycles = _getCycles(date);
+    final hours = _endHour - _startHour + 1;
+    final buckets = List.generate(hours, (_) => <int>[]);
+    for (final c in cycles) {
+      final parts = c.startTime.split(':');
+      final hour = int.tryParse(parts.first) ?? 0;
+      if (hour >= _startHour && hour <= _endHour) {
+        buckets[hour - _startHour].add(energy ? c.energy : c.complexity);
+      }
+    }
+    return buckets
+        .map((b) => b.isEmpty ? 0.0 : b.reduce((a, b) => a + b) / b.length)
+        .toList();
+  }
+
+  Widget _buildSummary() {
+    final weekly = _weeklyMinutes();
+    final dates = _availableDates();
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          DataTable(
+            columns: const [
+              DataColumn(label: Text('날짜')),
+              DataColumn(label: Text('집중 시간(분)')),
+            ],
+            rows: weekly.entries
+                .map((e) => DataRow(cells: [
+                      DataCell(Text(e.key)),
+                      DataCell(Text('${e.value}')),
+                    ]))
+                .toList(),
+          ),
+          const SizedBox(height: 20),
+          DropdownButton<String>(
+            value: _selectedDate,
+            items: dates
+                .map((d) => DropdownMenuItem(value: d, child: Text(d)))
+                .toList(),
+            onChanged: (v) => setState(() => _selectedDate = v ?? _selectedDate),
+          ),
+          const SizedBox(height: 12),
+          HourlyGraph(
+            levels: _hourlyLevels(_selectedDate, energy: true),
+            title: '시간별 에너지 레벨',
+          ),
+          const SizedBox(height: 20),
+          HourlyGraph(
+            levels: _hourlyLevels(_selectedDate, energy: false),
+            title: '시간별 난이도 레벨',
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDetail() {
+    final dates = _availableDates();
+    final cycles = _getCycles(_selectedDate);
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          DropdownButton<String>(
+            value: _selectedDate,
+            items: dates
+                .map((d) => DropdownMenuItem(value: d, child: Text(d)))
+                .toList(),
+            onChanged: (v) => setState(() => _selectedDate = v ?? _selectedDate),
+          ),
+          const SizedBox(height: 12),
+          DataTable(
+            columns: const [
+              DataColumn(label: Text('#')),
+              DataColumn(label: Text('목표')),
+            ],
+            rows: List.generate(cycles.length, (i) {
+              return DataRow(cells: [
+                DataCell(Text('${i + 1}')),
+                DataCell(Text(cycles[i].goal)),
+              ]);
+            }),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('레포트'),
+          bottom: const TabBar(tabs: [
+            Tab(text: 'Summary'),
+            Tab(text: 'Detail'),
+          ]),
+        ),
+        body: TabBarView(
+          children: [
+            _buildSummary(),
+            _buildDetail(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/feature/settings/settings_page.dart
+++ b/lib/feature/settings/settings_page.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import '../../data/firebase_service.dart';
+import '../../data/model/schedule.dart';
+
+class SettingsPage extends StatefulWidget {
+  const SettingsPage({super.key});
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  final FirebaseService _firebaseService = FirebaseService();
+  String _userId = '';
+  bool _loading = true;
+  final TextEditingController _focusController = TextEditingController();
+  final TextEditingController _breakController = TextEditingController();
+  final TextEditingController _longBreakController = TextEditingController();
+  final TextEditingController _intervalController = TextEditingController();
+
+  static const _dayKeys = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+  static const _startHour = 7;
+  static const _endHour = 23;
+
+  Map<String, List<String>> _schedule = {
+    for (var d in _dayKeys) d: List.filled(_endHour - _startHour + 1, 'none'),
+  };
+  final _slotTypes = ['none', 'breakfast', 'work', 'pomodoro'];
+
+  @override
+  void initState() {
+    super.initState();
+    _initialize();
+  }
+
+  Future<void> _initialize() async {
+    await _firebaseService.initializeFirebase();
+    _userId = (await _firebaseService.authenticateUser()) ?? '';
+    _firebaseService.getUserDataStream(_userId).listen((snapshot) {
+      final data = snapshot.data();
+      if (data != null) {
+        setState(() {
+          _focusController.text = '${data['focusMinutes'] ?? 25}';
+          _breakController.text = '${data['breakMinutes'] ?? 5}';
+          _longBreakController.text = '${data['longBreakMinutes'] ?? 15}';
+          _intervalController.text = '${data['longBreakInterval'] ?? 4}';
+          if (data['schedule'] != null) {
+            final schedJson = Map<String, dynamic>.from(data['schedule']);
+            _schedule = {
+              for (var e in schedJson.entries)
+                e.key: (e.value as List).map((v) => v.toString()).toList()
+            };
+          }
+          _loading = false;
+        });
+      }
+    });
+  }
+
+  void _save() {
+    final focus = int.tryParse(_focusController.text) ?? 25;
+    final brk = int.tryParse(_breakController.text) ?? 5;
+    final longBrk = int.tryParse(_longBreakController.text) ?? 15;
+    final interval = int.tryParse(_intervalController.text) ?? 4;
+    _firebaseService.saveUserData(_userId, {
+      'focusMinutes': focus,
+      'breakMinutes': brk,
+      'longBreakMinutes': longBrk,
+      'longBreakInterval': interval,
+      'schedule': Schedule(days: _schedule).toJson(),
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('저장되었습니다')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(title: const Text('설정')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _focusController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: '집중 시간(분)'),
+            ),
+            TextField(
+              controller: _breakController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: '휴식 시간(분)'),
+            ),
+            TextField(
+              controller: _longBreakController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: '긴 휴식 시간(분)'),
+            ),
+            TextField(
+              controller: _intervalController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: '긴 휴식 주기(사이클)'),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: DataTable(
+                  columns: [
+                    const DataColumn(label: Text('Day')),
+                    for (var h = _startHour; h <= _endHour; h++)
+                      DataColumn(label: Text('$h')),
+                  ],
+                  rows: _dayKeys.map((day) {
+                    final slots = _schedule[day]!;
+                    return DataRow(
+                      cells: [
+                        DataCell(Text(day.toUpperCase())),
+                        for (var i = 0; i < slots.length; i++)
+                          DataCell(
+                            DropdownButton<String>(
+                              value: slots[i],
+                              items: _slotTypes
+                                  .map((t) => DropdownMenuItem(
+                                        value: t,
+                                        child: Text(t),
+                                      ))
+                                  .toList(),
+                              onChanged: (v) => setState(() => slots[i] = v!),
+                            ),
+                          ),
+                      ],
+                    );
+                  }).toList(),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _save,
+              child: const Text('저장'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _focusController.dispose();
+    _breakController.dispose();
+    _longBreakController.dispose();
+    _intervalController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
-import 'feature/pomodoro/pomodoro_page.dart';
+import 'feature/home/home_page.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -21,7 +21,7 @@ class MyApp extends StatelessWidget {
         fontFamily: 'Inter',
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      home: const PomodoroPage(),
+      home: const HomePage(),
     );
   }
 }


### PR DESCRIPTION
## Summary
- create hourly graph widget for report charts
- restructure Report page with Summary and Detail tabs
- show weekly focus totals and hourly energy/difficulty graphs
- list cycle goals for the selected day

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482c8828b8833294b9e3b0b166a1cd