### PR TITLE
Rename schedule cycle count constant

### DIFF
--- a/lib/feature/pomodoro/pomodoro_page.dart
+++ b/lib/feature/pomodoro/pomodoro_page.dart
@@ -34,9 +34,9 @@ class _PomodoroPageState extends State<PomodoroPage> {
   final TextEditingController _goalController = TextEditingController();
 
   static const _dayKeys = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
-  static const _cycleCount = 17;
+  static const _scheduleCycleCount = 17;
   Map<String, List<String>> _schedule =
-      Schedule.empty(_dayKeys, _cycleCount).days;
+      Schedule.empty(_dayKeys, _scheduleCycleCount).days;
 
   int _focusMinutes = 25;
   int _breakMinutes = 5;

--- a/lib/feature/settings/settings_page.dart
+++ b/lib/feature/settings/settings_page.dart
@@ -21,7 +21,7 @@ class _SettingsPageState extends State<SettingsPage> {
   static const _dayKeys = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
   static const _startHour = 7;
   static const _endHour = 23;
-  static const _cycleCount = 17;
+  static const _scheduleCycleCount = 17;
 
   static List<String> _generateTimeOptions() {
     final times = <String>['none'];
@@ -37,7 +37,7 @@ class _SettingsPageState extends State<SettingsPage> {
   final List<String> _timeOptions = _generateTimeOptions();
 
   Map<String, List<String>> _schedule = {
-    for (var d in _dayKeys) d: List.filled(_cycleCount, 'none'),
+    for (var d in _dayKeys) d: List.filled(_scheduleCycleCount, 'none'),
   };
 
   @override
@@ -128,7 +128,7 @@ class _SettingsPageState extends State<SettingsPage> {
                   child: DataTable(
                     columns: [
                       const DataColumn(label: Text('Day')),
-                      for (var c = 1; c <= _cycleCount; c++)
+                      for (var c = 1; c <= _scheduleCycleCount; c++)
                         DataColumn(label: Text('Cycle $c')),
                     ],
                     rows: _dayKeys.map((day) {


### PR DESCRIPTION
## Summary
- rename duplicate `_cycleCount` constant to `_scheduleCycleCount`
- update schedule initialization loops to use the new name

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6848cdb24eb48332a2c80618d6e312a6