### PR TITLE
Fix scheduled start time for initial cycle

### DIFF
--- a/lib/feature/pomodoro/pomodoro_page.dart
+++ b/lib/feature/pomodoro/pomodoro_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dart:math';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:pomodoro_desktop/data/model/shop_item.dart';
@@ -86,7 +87,7 @@ class _PomodoroPageState extends State<PomodoroPage> {
 
   String _getScheduledStartTime() {
     final list = _schedule[_currentDayKey()];
-    final index = _cycleCount - 1;
+    final index = max(_cycleCount - 1, 0);
     if (list != null && index >= 0 && index < list.length) {
       final t = list[index];
       if (t != 'none') return t;


### PR DESCRIPTION
## Summary
- ensure `_getScheduledStartTime` returns cycle 1 schedule when `_cycleCount` is `0`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ebaeba60833299523e6c751e058b