### PR TITLE
Fix schedule saving to update timer settings

### DIFF
--- a/lib/feature/settings/settings_page.dart
+++ b/lib/feature/settings/settings_page.dart
@@ -122,7 +122,8 @@ class _SettingsPageState extends State<SettingsPage> {
       'breakMinutes': brk,
       'longBreakMinutes': longBrk,
       'longBreakInterval': interval,
-      'schedule': Schedule(days: _schedule).toJson(),
+      // Pass Schedule object directly so FirebaseService can serialize it
+      'schedule': Schedule(days: _schedule),
     });
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('저장되었습니다')),


### PR DESCRIPTION
## Summary
- pass `Schedule` instance when saving user settings

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684919a772288332afbc60b97ecbeffd