### PR TITLE
Support minute-based schedule times

### DIFF
--- a/lib/feature/settings/settings_page.dart
+++ b/lib/feature/settings/settings_page.dart
@@ -26,7 +26,7 @@ class _SettingsPageState extends State<SettingsPage> {
   static List<String> _generateTimeOptions() {
     final times = <String>['none'];
     for (var h = _startHour; h <= _endHour; h++) {
-      for (var m = 0; m < 60; m += 10) {
+      for (var m = 0; m < 60; m++) {
         times.add(
             '${h.toString().padLeft(2, '0')}:${m.toString().padLeft(2, '0')}');
       }


### PR DESCRIPTION
## Summary
- allow users to set schedule times at 1‑minute intervals

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491b48f4788332960bede76b27edca