### PR TITLE
Implement timer flow enhancements

### DIFF
--- a/lib/data/firebase_service.dart
+++ b/lib/data/firebase_service.dart
@@ -101,6 +101,7 @@ class FirebaseService {
         'cycleCount': 0,
         'energyHistory': [],
         'complexityHistory': [],
+        'currentComplexity': 1,
         'todayCycles': [],
         'history': [],
         'schedule': Schedule.empty(

--- a/lib/feature/pomodoro/widgets/timer_widget.dart
+++ b/lib/feature/pomodoro/widgets/timer_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 class TimerDisplay extends StatelessWidget {
   final bool isFocusMode;
+  final bool isLongBreak;
   final int minutes;
   final int seconds;
   final bool isActive;
@@ -14,6 +15,7 @@ class TimerDisplay extends StatelessWidget {
     required this.isFocusMode,
     required this.minutes,
     required this.seconds,
+    required this.isLongBreak,
     required this.isActive,
     required this.isPaused,
     required this.onStartPauseResume,
@@ -25,7 +27,9 @@ class TimerDisplay extends StatelessWidget {
     return Column(
       children: [
         Text(
-          isFocusMode ? '집중 시간!' : '휴식 시간!',
+          isFocusMode
+              ? '집중 시간!'
+              : (isLongBreak ? '긴 휴식 시간!' : '짧은 휴식 시간!'),
           style: TextStyle(
               fontSize: 16,
               fontWeight: FontWeight.w600,


### PR DESCRIPTION
## Summary
- show short/long break state in timer widget
- add database field for current complexity
- add save button for goal and complexity
- prompt for energy level after focus ends
- adjust mode switching logic

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68491d529a988332adf8354c8d6214c9