### PR TITLE
Fix cycle counter not persisting when goal edited

### DIFF
--- a/lib/feature/pomodoro/pomodoro_page.dart
+++ b/lib/feature/pomodoro/pomodoro_page.dart
@@ -223,6 +223,10 @@ class _PomodoroPageState extends State<PomodoroPage> {
         _cycleCount = 1;
         _updateStartTimeFromSchedule();
         _isLongBreak = false;
+        if (_userId.isNotEmpty) {
+          _firebaseService
+              .saveUserData(_userId, {'cycleCount': _cycleCount});
+        }
       }
       _timerController.startTimer(
         minutes: _minutes,
@@ -300,6 +304,10 @@ class _PomodoroPageState extends State<PomodoroPage> {
       _isPaused = false;
       if (goingToFocus) {
         _cycleCount += 1;
+        if (_userId.isNotEmpty) {
+          _firebaseService
+              .saveUserData(_userId, {'cycleCount': _cycleCount});
+        }
       }
       if (goingToFocus) {
         _updateStartTimeFromSchedule();


### PR DESCRIPTION
## Summary
- prevent cycle count from resetting when editing today's goal
- persist cycleCount to Firestore as soon as it's incremented

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684921657b5c83329f935a98bd727894