### PR TITLE
Fix cycle recording when no goal provided

### DIFF
--- a/lib/feature/pomodoro/pomodoro_page.dart
+++ b/lib/feature/pomodoro/pomodoro_page.dart
@@ -350,7 +350,6 @@ class _PomodoroPageState extends State<PomodoroPage> {
   }
 
   void _recordCycle(int energy, int complexity) {
-    if (_lastCycleGoal.isEmpty) return;
     final record = CycleRecord(
       goal: _lastCycleGoal,
       complexity: complexity,


### PR DESCRIPTION
## Summary
- ensure cycles are always stored by removing a guard in `_recordCycle`

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684924065dbc833285a202378f77e4d1