### PR TITLE
Fix energy history reset

### DIFF
--- a/lib/data/firebase_service.dart
+++ b/lib/data/firebase_service.dart
@@ -77,6 +77,28 @@ class FirebaseService {
         .set(dataToSave, SetOptions(merge: true));
   }
 
+  Future<void> appendCycleData({
+    required String userId,
+    required int energy,
+    required int complexity,
+    required int cycleCount,
+    required List<CycleRecord> todayCycles,
+  }) async {
+    await db
+        .collection('artifacts')
+        .doc('default-app-id')
+        .collection('users')
+        .doc(userId)
+        .collection('pomodoroData')
+        .doc('userState')
+        .set({
+          'energyHistory': FieldValue.arrayUnion([energy]),
+          'complexityHistory': FieldValue.arrayUnion([complexity]),
+          'cycleCount': cycleCount,
+          'todayCycles': todayCycles.map((e) => e.toJson()).toList(),
+        }, SetOptions(merge: true));
+  }
+
   Future<void> createInitialUserDataIfNotExists(String userId) async {
     final docRef = db
         .collection('artifacts')

--- a/lib/feature/pomodoro/pomodoro_page.dart
+++ b/lib/feature/pomodoro/pomodoro_page.dart
@@ -371,12 +371,13 @@ class _PomodoroPageState extends State<PomodoroPage> {
     });
 
     _recordCycle(energy, level);
-    _firebaseService.saveUserData(_userId, {
-      'energyHistory': _energyHistory,
-      'complexityHistory': _complexityHistory,
-      'cycleCount': _cycleCount,
-      'todayCycles': _todayCycles,
-    });
+    _firebaseService.appendCycleData(
+      userId: _userId,
+      energy: energy,
+      complexity: level,
+      cycleCount: _cycleCount,
+      todayCycles: _todayCycles,
+    );
     _switchMode();
   }
 


### PR DESCRIPTION
## Summary
- keep energy graph levels by storing cycle data with `arrayUnion`
- update cycle recording to use the new FirebaseService method

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7655a1a8833281d3d1ead12f46c1