### PR TITLE
Update energy graph redraw logic

### DIFF
--- a/lib/feature/pomodoro/pomodoro_page.dart
+++ b/lib/feature/pomodoro/pomodoro_page.dart
@@ -368,8 +368,10 @@ class _PomodoroPageState extends State<PomodoroPage> {
     final energy = _pendingEnergy ?? 1;
     setState(() {
       _currentComplexity = level;
-      _complexityHistory.add(level);
-      _energyHistory.add(energy);
+      // Create new list instances so widgets depending on these values
+      // receive updated references and repaint correctly.
+      _complexityHistory = List<int>.from(_complexityHistory)..add(level);
+      _energyHistory = List<int>.from(_energyHistory)..add(energy);
       debugPrint('_energyHistory: $_energyHistory');
       _pendingEnergy = null;
       _showComplexityPopup = false;
@@ -621,6 +623,7 @@ class _PomodoroPageState extends State<PomodoroPage> {
                   ),
                 if (_showGraph)
                   EnergyGraph(
+                    key: ValueKey(_energyHistory.length),
                     levels: _energyHistory,
                     onClose: () => setState(() => _showGraph = false),
                   ),


### PR DESCRIPTION
## Summary
- ensure energy graph repaints when energy is recorded
- rebuild energy graph widget whenever its data length changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857fb3fd7688332870a2a9033ba47a7