### PR TITLE
Print energy graph coordinates every cycle

### DIFF
--- a/lib/feature/pomodoro/pomodoro_page.dart
+++ b/lib/feature/pomodoro/pomodoro_page.dart
@@ -373,6 +373,12 @@ class _PomodoroPageState extends State<PomodoroPage> {
       _complexityHistory = List<int>.from(_complexityHistory)..add(level);
       _energyHistory = List<int>.from(_energyHistory)..add(energy);
       debugPrint('_energyHistory: $_energyHistory');
+      // Print graph coordinates each time energy is recorded for easier
+      // debugging without requiring the graph to be visible.
+      _EnergyPainter.printEnergyPoints(
+        _energyHistory,
+        const Size(330, 170),
+      );
       _pendingEnergy = null;
       _showComplexityPopup = false;
     });

--- a/lib/feature/pomodoro/widgets/energy_graph_widget.dart
+++ b/lib/feature/pomodoro/widgets/energy_graph_widget.dart
@@ -106,6 +106,22 @@ class _EnergyPainter extends CustomPainter {
   static const double _leftMargin = 700;
   static const double _bottomMargin = 20;
 
+  /// Logs the calculated points for the given [levels] and [size]. This can be
+  /// used outside of the painting context to debug the values that will be
+  /// drawn on the canvas.
+  static void printEnergyPoints(List<int> levels, Size size) {
+    final chartWidth = size.width - _leftMargin;
+    final chartHeight = size.height - _bottomMargin;
+    final stepX = chartWidth / (levels.length - 1 == 0 ? 1 : levels.length - 1);
+    final stepY = chartHeight / 3;
+
+    for (var i = 0; i < levels.length; i++) {
+      final x = _leftMargin + i * stepX;
+      final y = chartHeight - levels[i] * stepY;
+      debugPrint('Point $i: x=$x, y=$y, level=${levels[i]}');
+    }
+  }
+
   @override
   void paint(Canvas canvas, Size size) {
     final chartWidth = size.width - _leftMargin;


### PR DESCRIPTION
## Summary
- add static method `printEnergyPoints` to `_EnergyPainter`
- log graph coordinate points whenever energy is recorded

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858f99ec73c833289f80f59c9079467