### PR TITLE
Print energy graph coordinates every cycle

### DIFF
--- a/lib/feature/pomodoro/pomodoro_page.dart
+++ b/lib/feature/pomodoro/pomodoro_page.dart
@@ -373,6 +373,12 @@ class _PomodoroPageState extends State<PomodoroPage> {
       _complexityHistory = List<int>.from(_complexityHistory)..add(level);
       _energyHistory = List<int>.from(_energyHistory)..add(energy);
       debugPrint('_energyHistory: $_energyHistory');
+      // Print graph coordinates each time energy is recorded for easier
+      // debugging without requiring the graph to be visible.
+      EnergyPainter.printEnergyPoints(
+        _energyHistory,
+        const Size(330, 170),
+      );
       _pendingEnergy = null;
       _showComplexityPopup = false;
     });

--- a/lib/feature/pomodoro/widgets/energy_graph_widget.dart
+++ b/lib/feature/pomodoro/widgets/energy_graph_widget.dart
@@ -20,7 +20,7 @@ class EnergyGraph extends StatelessWidget {
       ),
       content: CustomPaint(
         size: const Size(330, 170),
-        painter: _EnergyPainter(levels),
+        painter: EnergyPainter(levels),
       ),
     );
   }
@@ -99,12 +99,28 @@ class _HourlyPainter extends CustomPainter {
   bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
 }
 
-class _EnergyPainter extends CustomPainter {
+class EnergyPainter extends CustomPainter {
   final List<int> levels;
-  _EnergyPainter(this.levels);
+  EnergyPainter(this.levels);
 
   static const double _leftMargin = 700;
   static const double _bottomMargin = 20;
+
+  /// Logs the calculated points for the given [levels] and [size]. This can be
+  /// used outside of the painting context to debug the values that will be
+  /// drawn on the canvas.
+  static void printEnergyPoints(List<int> levels, Size size) {
+    final chartWidth = size.width - _leftMargin;
+    final chartHeight = size.height - _bottomMargin;
+    final stepX = chartWidth / (levels.length - 1 == 0 ? 1 : levels.length - 1);
+    final stepY = chartHeight / 3;
+
+    for (var i = 0; i < levels.length; i++) {
+      final x = _leftMargin + i * stepX;
+      final y = chartHeight - levels[i] * stepY;
+      debugPrint('Point $i: x=$x, y=$y, level=${levels[i]}');
+    }
+  }
 
   @override
   void paint(Canvas canvas, Size size) {


### PR DESCRIPTION
## Summary
- add static method `printEnergyPoints` to `EnergyPainter`
- log graph coordinate points whenever energy is recorded
- fix reference to debug helper by making painter public

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858f99ec73c833289f80f59c9079467