### PR TITLE
Improve energy graph points

### DIFF
--- a/lib/feature/pomodoro/widgets/energy_graph_widget.dart
+++ b/lib/feature/pomodoro/widgets/energy_graph_widget.dart
@@ -149,6 +149,16 @@ class _EnergyPainter extends CustomPainter {
     }
     canvas.drawPath(path, paint);
 
+    // Draw circles for each point so they are visible on the graph.
+    final pointPaint = Paint()
+      ..color = Colors.purple
+      ..style = PaintingStyle.fill;
+    for (var i = 0; i < levels.length; i++) {
+      final x = _leftMargin + i * stepX;
+      final y = levels[i] * stepY;
+      canvas.drawCircle(Offset(x, y), 3, pointPaint);
+    }
+
     final axisPaint = Paint()
       ..color = Colors.grey
       ..strokeWidth = 1;


### PR DESCRIPTION
## Summary
- draw circles for each energy level on the graph so recorded values are visible

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859338c605883329b0e1da52d941227