### PR TITLE
Refactor energy graph display

### DIFF
--- a/lib/feature/pomodoro/pomodoro_page.dart
+++ b/lib/feature/pomodoro/pomodoro_page.dart
@@ -64,7 +64,6 @@ class _PomodoroPageState extends State<PomodoroPage> {
   bool _isGoalRefining = false;
   bool _isGeneratingBreakIdea = false;
   bool _showShop = false;
-  bool _showGraph = false;
   List<ShopItem> _inventory = [];
   int _cycleCount = 0;
   List<int> _energyHistory = [];
@@ -557,11 +556,6 @@ class _PomodoroPageState extends State<PomodoroPage> {
                 ),
                 const SizedBox(height: 8),
                 ElevatedButton(
-                  onPressed: () => setState(() => _showGraph = true),
-                  child: const Text('에너지 그래프'),
-                ),
-                const SizedBox(height: 8),
-                ElevatedButton(
                   onPressed: () => setState(() => _showHistory = true),
                   child: const Text('기록 보기'),
                 ),
@@ -623,12 +617,6 @@ class _PomodoroPageState extends State<PomodoroPage> {
                     shopItems: _shopItems,
                     onBuy: _buyItem,
                     onClose: () => setState(() => _showShop = false),
-                  ),
-                if (_showGraph)
-                  EnergyGraph(
-                    key: ValueKey(_energyHistory.length),
-                    levels: _energyHistory,
-                    onClose: () => setState(() => _showGraph = false),
                   ),
                 if (_showHistory)
                   CycleHistoryPopup(

--- a/lib/feature/pomodoro/widgets/energy_graph_widget.dart
+++ b/lib/feature/pomodoro/widgets/energy_graph_widget.dart
@@ -26,78 +26,6 @@ class EnergyGraph extends StatelessWidget {
   }
 }
 
-class HourlyGraph extends StatelessWidget {
-  final List<double> levels;
-  final String title;
-
-  const HourlyGraph({super.key, required this.levels, required this.title});
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(title,
-            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
-        const SizedBox(height: 8),
-        SizedBox(
-          height: 150,
-          width: double.infinity,
-          child: CustomPaint(painter: _HourlyPainter(levels)),
-        ),
-      ],
-    );
-  }
-}
-
-class _HourlyPainter extends CustomPainter {
-  final List<double> levels;
-
-  _HourlyPainter(this.levels);
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final paint = Paint()
-      ..color = Colors.purple
-      ..strokeWidth = 2
-      ..style = PaintingStyle.stroke;
-    final stepX = size.width / (levels.length - 1 == 0 ? 1 : levels.length - 1);
-    final stepY = size.height / 3;
-    final path = Path();
-    for (var i = 0; i < levels.length; i++) {
-      final x = i * stepX;
-      final y = size.height - levels[i] * stepY;
-      if (i == 0) {
-        path.moveTo(x, y);
-      } else {
-        path.lineTo(x, y);
-      }
-    }
-    canvas.drawPath(path, paint);
-
-    final axisPaint = Paint()
-      ..color = Colors.grey
-      ..strokeWidth = 1;
-    canvas.drawLine(
-        Offset(0, size.height), Offset(size.width, size.height), axisPaint);
-    canvas.drawLine(Offset(0, 0), Offset(0, size.height), axisPaint);
-
-    // y-axis labels
-    for (var i = 1; i <= 3; i++) {
-      final textPainter = TextPainter(
-        text: TextSpan(
-            text: '$i',
-            style: const TextStyle(color: Colors.black, fontSize: 10)),
-        textDirection: TextDirection.ltr,
-      )..layout();
-      textPainter.paint(canvas,
-          Offset(-20, size.height - i * stepY - textPainter.height / 2));
-    }
-  }
-
-  @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
-}
 
 class EnergyPainter extends CustomPainter {
   final List<int> levels;
@@ -200,4 +128,30 @@ class EnergyPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+}
+
+class EnergyGraphPanel extends StatelessWidget {
+  final List<int> levels;
+  final String title;
+
+  const EnergyGraphPanel({super.key, required this.levels, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title,
+            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
+        const SizedBox(height: 8),
+        SizedBox(
+          height: 170,
+          width: double.infinity,
+          child: CustomPaint(
+            painter: EnergyPainter(levels),
+          ),
+        ),
+      ],
+    );
+  }
 }

--- a/lib/feature/report/report_page.dart
+++ b/lib/feature/report/report_page.dart
@@ -19,8 +19,6 @@ class _ReportPageState extends State<ReportPage> {
   bool _loading = true;
   String _selectedDate = '';
 
-  static const _startHour = 7;
-  static const _endHour = 23;
 
   @override
   void initState() {
@@ -83,19 +81,10 @@ class _ReportPageState extends State<ReportPage> {
     return {for (var k in ordered) k: map[k] ?? 0};
   }
 
-  List<double> _hourlyLevels(String date, {required bool energy}) {
+  List<int> _hourlyLevels(String date, {required bool energy}) {
     final cycles = _getCycles(date);
-    final hours = _endHour - _startHour + 1;
-    final buckets = List.generate(hours, (_) => <int>[]);
-    for (final c in cycles) {
-      final parts = c.startTime.split(':');
-      final hour = int.tryParse(parts.first) ?? 0;
-      if (hour >= _startHour && hour <= _endHour) {
-        buckets[hour - _startHour].add(energy ? c.energy : c.complexity);
-      }
-    }
-    return buckets
-        .map((b) => b.isEmpty ? 0.0 : b.reduce((a, b) => a + b) / b.length)
+    return cycles
+        .map((c) => energy ? c.energy : c.complexity)
         .toList();
   }
 
@@ -129,14 +118,14 @@ class _ReportPageState extends State<ReportPage> {
                 setState(() => _selectedDate = v ?? _selectedDate),
           ),
           const SizedBox(height: 12),
-          HourlyGraph(
+          EnergyGraphPanel(
             levels: _hourlyLevels(_selectedDate, energy: true),
-            title: '시간별 에너지 레벨',
+            title: '사이클별 에너지 레벨',
           ),
           const SizedBox(height: 40),
-          HourlyGraph(
+          EnergyGraphPanel(
             levels: _hourlyLevels(_selectedDate, energy: false),
-            title: '시간별 난이도 레벨',
+            title: '사이클별 난이도 레벨',
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- show per-cycle data rather than hourly averages in report page
- inline energy/complexity graphs using `EnergyGraphPanel`
- remove unused hourly graph widget
- drop energy graph popup from Pomodoro page

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859384552888332b4c7ea85f00c77b9