### PR TITLE
Update report graphs for custom focus time

### DIFF
--- a/lib/feature/pomodoro/widgets/energy_graph_widget.dart
+++ b/lib/feature/pomodoro/widgets/energy_graph_widget.dart
@@ -3,8 +3,14 @@ import 'package:flutter/material.dart';
 class EnergyGraph extends StatelessWidget {
   final List<int> levels;
   final VoidCallback onClose;
+  final List<String>? startTimes;
 
-  const EnergyGraph({super.key, required this.levels, required this.onClose});
+  const EnergyGraph({
+    super.key,
+    required this.levels,
+    required this.onClose,
+    this.startTimes,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -20,7 +26,7 @@ class EnergyGraph extends StatelessWidget {
       ),
       content: CustomPaint(
         size: const Size(330, 170),
-        painter: EnergyPainter(levels),
+        painter: EnergyPainter(levels, startTimes: startTimes),
       ),
     );
   }
@@ -29,7 +35,8 @@ class EnergyGraph extends StatelessWidget {
 
 class EnergyPainter extends CustomPainter {
   final List<int> levels;
-  EnergyPainter(this.levels);
+  final List<String>? startTimes;
+  EnergyPainter(this.levels, {this.startTimes});
 
   // Reduced left margin so the graph width reflects the number of cycles.
   static const double _leftMargin = 40;
@@ -42,11 +49,11 @@ class EnergyPainter extends CustomPainter {
     final chartWidth = size.width - _leftMargin;
     final chartHeight = size.height - _bottomMargin;
     final stepX = chartWidth / (levels.length - 1 == 0 ? 1 : levels.length - 1);
-    final stepY = chartHeight / 3;
+    final stepY = chartHeight / 2;
 
     for (var i = 0; i < levels.length; i++) {
       final x = _leftMargin + i * stepX;
-      final y = levels[i] * stepY;
+      final y = chartHeight - (levels[i] - 1) * stepY;
       debugPrint('Point $i: x=$x, y=$y, level=${levels[i]}');
     }
   }
@@ -62,12 +69,12 @@ class EnergyPainter extends CustomPainter {
       ..style = PaintingStyle.stroke;
 
     final stepX = chartWidth / (levels.length - 1 == 0 ? 1 : levels.length - 1);
-    final stepY = chartHeight / 3;
+    final stepY = chartHeight / 2;
 
     final path = Path();
     for (var i = 0; i < levels.length; i++) {
       final x = _leftMargin + i * stepX;
-      final y = levels[i] * stepY;
+      final y = chartHeight - (levels[i] - 1) * stepY;
       debugPrint('Point $i: x=$x, y=$y, level=${levels[i]}');
       if (i == 0) {
         path.moveTo(x, y);
@@ -83,7 +90,7 @@ class EnergyPainter extends CustomPainter {
       ..style = PaintingStyle.fill;
     for (var i = 0; i < levels.length; i++) {
       final x = _leftMargin + i * stepX;
-      final y = levels[i] * stepY;
+      final y = chartHeight - (levels[i] - 1) * stepY;
       canvas.drawCircle(Offset(x, y), 3, pointPaint);
     }
 
@@ -106,16 +113,16 @@ class EnergyPainter extends CustomPainter {
       textPainter.paint(
           canvas,
           Offset(_leftMargin - 8 - textPainter.width,
-              i * stepY - textPainter.height / 2));
+              chartHeight - (i - 1) * stepY - textPainter.height / 2));
     }
 
-    // x-axis labels (minutes)
-    const cycleMinutes = 25;
+    // x-axis labels
     for (var i = 0; i < levels.length; i++) {
-      final minute = (i + 1) * cycleMinutes;
+      final label =
+          startTimes != null && startTimes!.length > i ? startTimes![i] : '${(i + 1) * 25}';
       final textPainter = TextPainter(
         text: TextSpan(
-            text: '$minute',
+            text: label,
             style: const TextStyle(color: Colors.black, fontSize: 10)),
         textDirection: TextDirection.ltr,
       )..layout();
@@ -133,8 +140,10 @@ class EnergyPainter extends CustomPainter {
 class EnergyGraphPanel extends StatelessWidget {
   final List<int> levels;
   final String title;
+  final List<String>? startTimes;
 
-  const EnergyGraphPanel({super.key, required this.levels, required this.title});
+  const EnergyGraphPanel(
+      {super.key, required this.levels, required this.title, this.startTimes});
 
   @override
   Widget build(BuildContext context) {
@@ -148,7 +157,7 @@ class EnergyGraphPanel extends StatelessWidget {
           height: 170,
           width: double.infinity,
           child: CustomPaint(
-            painter: EnergyPainter(levels),
+            painter: EnergyPainter(levels, startTimes: startTimes),
           ),
         ),
       ],

--- a/lib/feature/report/report_page.dart
+++ b/lib/feature/report/report_page.dart
@@ -18,6 +18,7 @@ class _ReportPageState extends State<ReportPage> {
   List<CycleRecord> _todayCycles = [];
   bool _loading = true;
   String _selectedDate = '';
+  int _focusMinutes = 25;
 
 
   @override
@@ -39,6 +40,7 @@ class _ReportPageState extends State<ReportPage> {
           _todayCycles = (data['todayCycles'] as List? ?? [])
               .map((e) => CycleRecord.fromJson(Map<String, dynamic>.from(e)))
               .toList();
+          _focusMinutes = data['focusMinutes'] ?? 25;
           _selectedDate = _formatDate(DateTime.now());
           _loading = false;
         });
@@ -75,7 +77,7 @@ class _ReportPageState extends State<ReportPage> {
       final day = now.subtract(Duration(days: i));
       final key = _formatDate(day);
       final cycles = _getCycles(key);
-      map[key] = cycles.length * 25;
+      map[key] = cycles.length * _focusMinutes;
     }
     final ordered = map.keys.toList()..sort();
     return {for (var k in ordered) k: map[k] ?? 0};
@@ -86,6 +88,11 @@ class _ReportPageState extends State<ReportPage> {
     return cycles
         .map((c) => energy ? c.energy : c.complexity)
         .toList();
+  }
+
+  List<String> _startTimesFor(String date) {
+    final cycles = _getCycles(date);
+    return cycles.map((c) => c.startTime).toList();
   }
 
   Widget _buildSummary() {
@@ -120,11 +127,13 @@ class _ReportPageState extends State<ReportPage> {
           const SizedBox(height: 12),
           EnergyGraphPanel(
             levels: _hourlyLevels(_selectedDate, energy: true),
+            startTimes: _startTimesFor(_selectedDate),
             title: '사이클별 에너지 레벨',
           ),
           const SizedBox(height: 40),
           EnergyGraphPanel(
             levels: _hourlyLevels(_selectedDate, energy: false),
+            startTimes: _startTimesFor(_selectedDate),
             title: '사이클별 난이도 레벨',
           ),
         ],


### PR DESCRIPTION
## Summary
- use user-configured focus minutes for weekly totals
- show cycle start time on X‑axis of report graphs
- invert Y‑axis so level 3 appears at the top

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859436ab0588332b24069f89647b602