### PR TITLE
Implement midnight reset and popup dialogs

### DIFF
--- a/lib/data/firebase_service.dart
+++ b/lib/data/firebase_service.dart
@@ -126,6 +126,7 @@ class FirebaseService {
         'currentComplexity': 1,
         'todayCycles': [],
         'history': [],
+        'lastCycleDate': '',
         'schedule': Schedule.empty(
           const ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
           17,


### PR DESCRIPTION
## Summary
- auto-reset cycles each day using stored `lastCycleDate`
- show goal, energy, and complexity prompts as modal dialogs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859461158c88332a512ac6f03021bd8