### PR TITLE
Fix break timer duration reset

### DIFF
--- a/lib/feature/pomodoro/pomodoro_page.dart
+++ b/lib/feature/pomodoro/pomodoro_page.dart
@@ -199,8 +199,16 @@ class _PomodoroPageState extends State<PomodoroPage> {
             final record = DayRecord.fromJson(Map<String, dynamic>.from(day));
             _history[record.date] = record.cycles;
           });
-          _minutes = _focusMinutes;
-          _seconds = 0;
+          if (!_isActive) {
+            if (_isFocusMode) {
+              _minutes = _focusMinutes;
+            } else {
+              _isLongBreak =
+                  _cycleCount % _longBreakInterval == 0 && _cycleCount > 0;
+              _minutes = _isLongBreak ? _longBreakMinutes : _breakMinutes;
+            }
+            _seconds = 0;
+          }
           _isLoading = false;
           _updateStartTimeFromSchedule();
           _checkDailyReset();


### PR DESCRIPTION
## Summary
- ensure break mode loads the correct duration when user data updates

## Testing
- `dart format lib/feature/pomodoro/pomodoro_page.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8f50fd6883329bb23a1d3c3d4928